### PR TITLE
Misc Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+.idea/

--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ var createCustomCheckerCreator = exports.createCustomCheckerCreator = function(c
   return function checkerCreator() {
     var args = Array.prototype.slice.apply(arguments);
     return createCustomChecker(function(isOptional) {
-      return creator.apply(null, [isOptional].concat(args))
+      return creator.apply(null, args);
     }, args, checkerCreator);
   }
 };
 
-exports.createSimpleChecker = createCustomCheckerCreator(function(isOptional, checkIsValid) {
+exports.createSimpleChecker = createCustomCheckerCreator(function(checkIsValid) {
   return function(props, propName, componentName, location) {
     if (!checkIsValid(props[propName])) {
       return new Error(
@@ -41,7 +41,7 @@ exports.createSimpleChecker = createCustomCheckerCreator(function(isOptional, ch
   };
 });
 
-types.exactShape = createCustomCheckerCreator(function(isOptional, shape) {
+types.exactShape = createCustomCheckerCreator(function(shape) {
   return function(props, propName, componentName, location) {
     var diff = keysDiff(shape, props[propName]);
     if (diff) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var createCustomChecker = exports.createCustomChecker = function(creator, args, 
   });
 };
 
-var createCustomCheckerCreator = exports.createCustomChecker = function(creator) {
+var createCustomCheckerCreator = exports.createCustomCheckerCreator = function(creator) {
   return function checkerCreator() {
     var args = Array.prototype.slice.apply(arguments);
     return createCustomChecker(function(isOptional) {

--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ Object.keys(propTypes).forEach(function(key) {
 var createCustomChecker = exports.createCustomChecker = function(creator, args) {
   args = Array.prototype.slice.apply(args || []);
   return createRequiredChecker(function(isOptional) {
-    var checker = creator.apply(null, [isOptional].concat(args));
-    return addInspectors(isOptional, args, checker);
+    return addInspectors(isOptional, args, creator(isOptional));
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,13 @@ Object.keys(propTypes).forEach(function(key) {
 var createCustomChecker = exports.createCustomChecker = function(creator, args, type) {
   args = Array.prototype.slice.apply(args || []);
   return createRequiredChecker(function(isOptional) {
-    return addInspectors(isOptional, args, type, creator(isOptional));
+    var checker = creator(isOptional);
+    return addInspectors(isOptional, args, type, function(props, propName) {
+      if (isOptional && props[propName] == null) {
+        return null;
+      }
+      return checker.apply(null, arguments);
+    });
   });
 };
 
@@ -26,9 +32,6 @@ var createCustomCheckerCreator = exports.createCustomChecker = function(creator)
 
 exports.createSimpleChecker = createCustomCheckerCreator(function(isOptional, checkIsValid) {
   return function(props, propName, componentName, location) {
-    if (isOptional && props[propName] == null) {
-      return null;
-    }
     if (!checkIsValid(props[propName])) {
       return new Error(
         'Invalid ' + location + ' `' + propName + '` supplied to `' + componentName + '`.'
@@ -40,9 +43,6 @@ exports.createSimpleChecker = createCustomCheckerCreator(function(isOptional, ch
 
 types.exactShape = createCustomCheckerCreator(function(isOptional, shape) {
   return function(props, propName, componentName, location) {
-    if (isOptional && props[propName] == null) {
-      return null;
-    }
     var diff = keysDiff(shape, props[propName]);
     if (diff) {
       return new Error('Invalid ' + location + ' `' + propName + '` supplied to `' + componentName + '`: ' + diff + '.');

--- a/index.js
+++ b/index.js
@@ -23,15 +23,15 @@ if (types.element) {
 }
 
 exports.createCustomChecker = function(isValid) {
-  return function(props, propName, componentName, location, propFullName) {
+  return function(props, propName, componentName, location) {
     if (!isValid(props[propName])) {
       return new Error(
-        'Invalid `' + propName + '` supplied to `' + componentName + '`'
-      )
+        'Invalid ' + location + ' `' + propName + '` supplied to `' + componentName + '`.'
+      );
     }
     return null;
   }
-}
+};
 
 function keysDiff(o1, o2) {
   var map1 = {};
@@ -61,19 +61,22 @@ types.exactShape = function(shape) {
       }
       return types.shape(shape).apply(this, arguments);
     };
-  }
+  };
   var checker = makeChecker(false);
   checker.isOptional = makeChecker(true);
   return checker;
-}
+};
 
 exports.check = function(propTypeValidator) {
-  var curriedCheck = function(value) {
+  var curriedCheck = function(value, label) {
+    label = label || 'zan-check';
     var testObj = { value: value };
-    return propTypeValidator(testObj, 'value', 'zan check');
+    return propTypeValidator(testObj, 'value', label, 'prop');
   };
-  return arguments.length > 1 ? curriedCheck(arguments[1]) : curriedCheck;
-}
+  return arguments.length > 1
+    ? curriedCheck.apply(null, Array.prototype.slice.call(arguments, 1))
+    : curriedCheck;
+};
 
 var recursive = exports.recursive = function(object, isRecursive) {
   if (typeof object !== 'object' || object === null) {
@@ -90,4 +93,4 @@ var recursive = exports.recursive = function(object, isRecursive) {
     }
   }
   return isRecursive ? types.shape(ret) : ret;
-}
+};

--- a/index.js
+++ b/index.js
@@ -30,11 +30,6 @@ function wrapChecker(reactChecker) {
   return checker;
 }
 
-if (types.element) {
-  types.node = types.element;
-  types.element = undefined;
-}
-
 exports.createCustomChecker = function(isValid) {
   return function(props, propName, componentName, location) {
     if (!isValid(props[propName])) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "test object types (similar to React.PropTypes)",
   "main": "index.js",
   "scripts": {
-    "test-cov":    "node ./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- --reporter dot --require babel/register",
+    "test-cov": "node ./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- --reporter dot --require babel/register",
     "test-travis": "node ./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- -R spec --require babel/register",
     "test": "mocha --recursive --compilers js:babel/register"
   },
@@ -30,7 +30,8 @@
     "coveralls": "^2.11.4",
     "expect": "^1.10.0",
     "istanbul": "^0.3.20",
-    "mocha": "^2.3.2"
+    "mocha": "^2.3.2",
+    "react": "^0.14.7"
   },
   "peerDependencies": {
     "react": ">=0.12.0"

--- a/test.js
+++ b/test.js
@@ -67,6 +67,15 @@ describe('zan', () => {
     expect(exactShape({num: number}).inspectArgs()).toEqual([{num: number}]);
   });
 
+  it ('can predictably inspect type type of an inspector', () => {
+    expect(number.inspectType()).toEqual(number);
+    expect(shape({num: number}).inspectType()).toEqual(shape);
+    expect(shape({num: number}.isOptional).inspectType()).toEqual(shape);
+    expect(shape({num: number}).isOptional.isRequired.inspectType()).toEqual(shape);
+    expect(exactShape({num: number}).inspectType()).toEqual(exactShape);
+    expect(exactShape({num: number}).isOptional.inspectType()).toEqual(exactShape);
+  });
+
   it('can do optional shapes',() => {
     expect( check(shape({num: number}), {num: 22} )).toBeFalsy();
     expect( check(shape({num: number}), {num: 'x'} )).toBeAn(Error);

--- a/test.js
+++ b/test.js
@@ -37,6 +37,18 @@ describe('zan', () => {
     expect(  check(number.isOptional, 'x')  ).toBeAn(Error);
   });
 
+  it('can convert optional checks to required checks', () => {
+    expect(check(number.isOptional.isRequired, null)).toBeAn(Error);
+    expect(check(shape({num: number}).isOptional.isRequired, null)).toBeAn(Error);
+    expect(check(exactShape({num: number}).isOptional.isRequired, null)).toBeAn(Error);
+  });
+
+  it('can convert optional checks to required checks and back again', () => {
+    expect(check(number.isOptional.isRequired.isOptional, null)).toBeFalsy();
+    expect(check(shape({num: number}).isOptional.isRequired.isOptional, null)).toBeFalsy();
+    expect(check(exactShape({num: number}).isOptional.isRequired.isOptional, null)).toBeFalsy();
+  });
+
   it('can do optional shapes',() => {
     expect( check(shape({num: number}), {num: 22} )).toBeFalsy();
     expect( check(shape({num: number}), {num: 'x'} )).toBeAn(Error);

--- a/test.js
+++ b/test.js
@@ -49,6 +49,24 @@ describe('zan', () => {
     expect(check(exactShape({num: number}).isOptional.isRequired.isOptional, null)).toBeFalsy();
   });
 
+  it ('can statically inspect if a type checker is requried or optional', () => {
+    expect(number.inspectIsOptional()).toEqual(false);
+    expect(number.isOptional.inspectIsOptional()).toEqual(true);
+    expect(number.isOptional.isRequired.inspectIsOptional()).toEqual(false);
+    expect(shape({num: number}).inspectIsOptional()).toEqual(false);
+    expect(shape({num: number}).isOptional.inspectIsOptional()).toEqual(true);
+    expect(shape({num: number}).isOptional.isRequired.inspectIsOptional()).toEqual(false);
+    expect(exactShape({num: number}).inspectIsOptional()).toEqual(false);
+    expect(exactShape({num: number}).isOptional.inspectIsOptional()).toEqual(true);
+    expect(exactShape({num: number}).isOptional.isRequired.inspectIsOptional()).toEqual(false);
+  });
+
+  it ('can statically inspect the arguments passed to a checker', () => {
+    expect(number.inspectArgs()).toEqual([]);
+    expect(shape({num: number}).inspectArgs()).toEqual([{num: number}]);
+    expect(exactShape({num: number}).inspectArgs()).toEqual([{num: number}]);
+  });
+
   it('can do optional shapes',() => {
     expect( check(shape({num: number}), {num: 22} )).toBeFalsy();
     expect( check(shape({num: number}), {num: 'x'} )).toBeAn(Error);

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 const nodeInstance = <div></div>;
 
-import { check, types, createCustomChecker, recursive } from './';
+import { check, types, createSimpleChecker, recursive } from './';
 
 const {
   any,
@@ -104,14 +104,22 @@ describe('zan', () => {
     });
 
     it('is able to produce custom checkers', function() {
-      var customValidator = createCustomChecker(value => /(foo|bar)g?/.test(value) );
+      var customValidator = createSimpleChecker(value => /(foo|bar)g?/.test(value) );
       expect(check(customValidator, 'foo')).toBeFalsy();
       expect(check(customValidator, 'foog')).toBeFalsy();
       expect(check(customValidator, 'bar')).toBeFalsy();
       expect(check(customValidator, 'barg')).toBeFalsy();
       expect(check(customValidator, 'fog')).toBeAn(Error);
     });
+  });
 
+  describe('custom validators', () => {
+    it ('should have isOptional and isRequired extentions', () => {
+      var customValidator = createSimpleChecker(value => /(foo|bar)g?/.test(value) );
+      expect(check(customValidator, null)).toBeAn(Error);
+      expect(check(customValidator.isRequired, null)).toBeAn(Error);
+      expect(check(customValidator.isOptional, null)).toBeFalsy();
+    });
   });
 
   describe('complex types', function() {


### PR DESCRIPTION
I forked zan and made a variety of changes to support my use-case. Changes include:
1. Update custom error messages to match the React PropType form
2. Support chaining `type.isOptional.isRequired.isOptional...`
3. Add static inspection methods to types: `inspectIsOptional()` and `inspectArgs()`
4. Rename `createCustomChecker()` to `createSimpleChecker()`. Add `.isOptional` handling and inspection methods.
5. Add `createCustomChecker()` method that makes it easy to add `.isOptional` handling and inspection methods to custom type checkers. Used internally for `exactShape()`.

If you'd like to merge these changes then please review. Once reviewed, I'll also update the documentation. Otherwise I'm happy to work off my fork.
