### PR TITLE
Simplify API and Update Documentation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "presets": ["es2015", "stage-0", "react"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.12"
   - "iojs"
   - "4"
+  - "5"
 script: "npm run-script test-travis"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "zan",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "test object types (similar to React.PropTypes)",
   "main": "index.js",
   "scripts": {
-    "test-cov": "node ./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- --reporter dot --require babel/register",
-    "test-travis": "node ./node_modules/istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- -R spec --require babel/register",
-    "test": "mocha --recursive --compilers js:babel/register"
+    "test-cov": "nyc npm test && nyc report --reporter=lcov",
+    "test-travis": "nyc npm test && nyc report --reporter=lcov",
+    "test": "mocha --recursive --compilers js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,15 @@
   },
   "homepage": "https://github.com/kolodny/zan#readme",
   "devDependencies": {
-    "babel": "^5.8.23",
+    "babel-core": "^6.7.6",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
     "coveralls": "^2.11.4",
     "expect": "^1.10.0",
-    "istanbul": "^0.3.20",
     "mocha": "^2.3.2",
+    "nyc": "^6.4.0",
     "react": "^0.14.7"
   },
   "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 const nodeInstance = <div></div>;
 
-import { check, types, createSimpleChecker, recursive } from './';
+import { check, types, createCustomChecker, recursive } from './';
 
 const {
   any,
@@ -113,7 +113,11 @@ describe('zan', () => {
     });
 
     it('is able to produce custom checkers', function() {
-      var customValidator = createSimpleChecker(value => /(foo|bar)g?/.test(value) );
+      var customValidator = createCustomChecker((props, propName) => {
+        if (!(/(foo|bar)g?/.test(props[propName]))) {
+          return new Error('Value is not "foo" or "bar"');
+        }
+      });
       expect(check(customValidator, 'foo')).toBeFalsy();
       expect(check(customValidator, 'foog')).toBeFalsy();
       expect(check(customValidator, 'bar')).toBeFalsy();
@@ -124,7 +128,11 @@ describe('zan', () => {
 
   describe('custom validators', () => {
     it ('should have isOptional and isRequired extentions', () => {
-      var customValidator = createSimpleChecker(value => /(foo|bar)g?/.test(value) );
+      var customValidator = createCustomChecker((props, propName) => {
+        if (!(/(foo|bar)g?/.test(props[propName]))) {
+          return new Error('Value is not "foo" or "bar"');
+        }
+      });
       expect(check(customValidator, null)).toBeAn(Error);
       expect(check(customValidator.isRequired, null)).toBeAn(Error);
       expect(check(customValidator.isOptional, null)).toBeFalsy();
@@ -246,7 +254,7 @@ describe('zan', () => {
     it('can check at least one level', () => {
       const deepChecker = recursive({
         value: {
-          level1: string,
+          level1: string
         }
       }).value;
       expect( check(deepChecker, {level1: 123} )).toBeAn(Error);


### PR DESCRIPTION
Changes:
1. Add detailed and update documentation
2. Change `createCustomChecker` to 
   - Take a checker directly instead of a function that returns a checker
   - Internally handle missing data
   - Prefix custom error messages with the location of the error
3. Remove `createSimpleChecker` since `createCustomChecker` is now also simple, but is more powerful.
